### PR TITLE
Basic implementation of multi buffer editor

### DIFF
--- a/src/ewig/application.hpp
+++ b/src/ewig/application.hpp
@@ -55,7 +55,11 @@ struct application
     coord window_size;
     key_map keys;
     key_seq input;
-    buffer current;
+    buffer current() const {
+        return buffers[current_buffer];
+    }
+    size_t current_buffer;
+    std::vector<buffer> buffers;
     immer::vector<text> clipboard;
     immer::vector<message> messages;
 };
@@ -72,6 +76,8 @@ application clear_input(application state);
 
 result<application, action> quit(application app);
 result<application, action> save(application app);
+result<application, action> next_buffer(application app);
+result<application, action> previous_buffer(application app);
 result<application, action> load(application app, const std::string& fname);
 result<application, action> update(application state, action ev);
 

--- a/src/ewig/buffer.hpp
+++ b/src/ewig/buffer.hpp
@@ -78,6 +78,7 @@ struct snapshot
 
 struct buffer
 {
+    size_t id;
     file from;
     text content;
     coord cursor;
@@ -87,9 +88,9 @@ struct buffer
     std::optional<std::size_t> history_pos;
 };
 
-struct load_progress_action { loading_file file; };
-struct load_done_action { existing_file file; };
-struct load_error_action { existing_file file; std::exception_ptr err; };
+struct load_progress_action { size_t buffer_id; loading_file file; };
+struct load_done_action { size_t buffer_id; existing_file file; };
+struct load_error_action { size_t buffer_id; existing_file file; std::exception_ptr err; };
 struct save_progress_action { saving_file file; };
 struct save_done_action { existing_file file; };
 struct save_error_action { existing_file file; std::exception_ptr err; };
@@ -133,7 +134,7 @@ bool is_dirty(const buffer& buf);
 
 std::pair<buffer, std::string> update_buffer(buffer buf, buffer_action ac);
 
-result<buffer, buffer_action> load_buffer(buffer, const std::string& fname);
+result<buffer, buffer_action> load_buffer(size_t buffer_id, buffer, const std::string& fname);
 result<buffer, buffer_action> save_buffer(buffer buf);
 
 index expand_tabs(const line& ln, index col);

--- a/src/ewig/draw.cpp
+++ b/src/ewig/draw.cpp
@@ -167,17 +167,17 @@ void draw(const application& app)
 
     auto size = editor_size(app);
     ::move(0, 0);
-    draw_text(app.current, size);
+    draw_text(app.current(), size);
 
     ::move(size.row, 0);
-    draw_mode_line(app.current, size.col);
+    draw_mode_line(app.current(), size.col);
 
     if (!app.messages.empty()) {
         ::move(size.row + 1, 0);
         draw_message(app.messages.back());
     }
 
-    draw_text_cursor(app.current, size);
+    draw_text_cursor(app.current(), size);
     ::refresh();
 }
 


### PR DESCRIPTION
This is more of an RFC, it implements multiple buffers using a std::vector. There are a few changes I'd be interested in making but wanted to see what your preferred approach would be. For instance I'm assigning a numerical id to buffers, it'd probably be better to use a unique id (perhaps based on a uuid) and place the buffers into a map. I've also added a default *scratch* buffer, which I thought would be useful if the intent is to include a scheme interpreter in the editor.

