### PR TITLE
Removed submodule command from build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This will download all required dependencies and create an isolated
 environment in which you can use these dependencies, without polluting
 your system.
 
-Then you can proceed to **generate a
+Then you can **generate a
 development** project using [CMake](https://cmake.org/).
 ```
     mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ This will download all required dependencies and create an isolated
 environment in which you can use these dependencies, without polluting
 your system.
 
-Then you can **generate a
-development** project using [CMake](https://cmake.org/).
+Then you can **generate a development** project using [CMake](https://cmake.org/).
 ```
     mkdir build && cd build
     cmake ..

--- a/README.md
+++ b/README.md
@@ -59,10 +59,9 @@ This will download all required dependencies and create an isolated
 environment in which you can use these dependencies, without polluting
 your system.
 
-Then you can proceed to download the git submodules and **generate a
+Then you can proceed to **generate a
 development** project using [CMake](https://cmake.org/).
 ```
-    git submodule update --recursive --init
     mkdir build && cd build
     cmake ..
 ```


### PR DESCRIPTION
It seems that, a part of instruction from README is outdated and one step (invoking `git submodule update`) is not necessary anymore. Therefore I've removed it.