### PR TITLE
Make it work with newer nixpkgs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v11
+      - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-19.09
       - uses: cachix/cachix-action@v6
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v11
+      - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v6

--- a/default.nix
+++ b/default.nix
@@ -3,10 +3,9 @@
 with import nixpkgs {};
 
 let
-  deps = import ./nix/deps.nix { inherit nixpkgs; };
-in
+deps = import ./nix/deps.nix { inherit nixpkgs; };
 
-stdenv.mkDerivation rec {
+releaseBuild = stdenv.mkDerivation rec {
   name = "ewig-git";
   version = "git";
   src = builtins.filterSource (path: type:
@@ -29,4 +28,14 @@ stdenv.mkDerivation rec {
     description = "The eternal text editor";
     license     = licenses.gpl3;
   };
-}
+
+  passthru.debug = releaseBuild.overrideAttrs (_: {
+    makeFlags = "ewig-debug";
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ewig-debug $out/bin/ewig-debug
+    '';
+  });
+};
+
+in releaseBuild

--- a/default.nix
+++ b/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     deps.utfcpp
     deps.lager
   ];
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage    = "https://github.com/arximboldi/ewig";
     description = "The eternal text editor";
     license     = licenses.gpl3;

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -66,7 +66,7 @@ rec {
       owner = "etr";
       repo = "libhttpserver";
       rev = commit;
-      hash = "sha256-reGFjtLNUNOiq6wGR5FmAZT6lv1UZyQoS8GxARfDkIY=";
+      sha256 = "sha256-reGFjtLNUNOiq6wGR5FmAZT6lv1UZyQoS8GxARfDkIY=";
     };
     propagatedBuildInputs = [ libmicrohttpd ];
     nativeBuildInputs = [ autoreconfHook gcc7 ];

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -15,7 +15,7 @@ rec {
     };
     nativeBuildInputs = [ cmake ];
     buildInputs = [ boost ];
-    meta = with stdenv.lib; {
+    meta = with lib; {
       homepage = "http://sinusoid.es/immer";
       description = "Immutable data structures for C++";
       license = licenses.lgpl3;
@@ -34,7 +34,7 @@ rec {
     };
     dontBuild = true;
     installPhase = "mkdir -vp $out/include; cp -vr $src/include/* $out/include/";
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description = "Syntax sugar for variants";
       license = licenses.mit;
     };
@@ -52,7 +52,7 @@ rec {
     };
     dontBuild = true;
     installPhase = "mkdir -vp $out/include; cp -vr $src/source/* $out/include/";
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description = "UTF-8 with C++ in a Portable Way";
       license = licenses.mit;
     };
@@ -69,7 +69,7 @@ rec {
       sha256 = "1qg5frqvfhb8bpfiz9wivwjz2icy3si112grv188kgypws58n832";
     };
     propagatedBuildInputs = [ libmicrohttpd ];
-    nativeBuildInputs = [ autoreconfHook gcc5 ];
+    nativeBuildInputs = [ autoreconfHook gcc7 ];
     configureScript = "../configure";
     preConfigure = ''
       substituteInPlace ./configure \
@@ -77,7 +77,7 @@ rec {
         --replace "/bin/pwd" "${coreutils}/bin/pwd"
       mkdir build && cd build
     '';
-    meta = with stdenv.lib; {
+    meta = with lib; {
       homepage = "https://github.com/etr/libhttpserver";
       description = "C++ library for creating an embedded Rest HTTP server (and more)";
       license = licenses.lgpl2;
@@ -96,7 +96,7 @@ rec {
     };
     nativeBuildInputs = [ cmake ];
     cmakeFlags="-DJUST_INSTALL_CEREAL=true";
-    meta = with stdenv.lib; {
+    meta = with lib; {
       homepage = "http://uscilab.github.io/cereal";
       description = "A C++11 library for serialization";
       license = licenses.bsd3;
@@ -127,7 +127,7 @@ rec {
       libhttpserver
       cereal
     ];
-    meta = with stdenv.lib; {
+    meta = with lib; {
       homepage    = "https://github.com/arximboldi/lager";
       description = "library for functional interactive c++ programs";
       license     = licenses.lgpl3Plus;

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -61,12 +61,12 @@ rec {
   libhttpserver = stdenv.mkDerivation rec {
     name = "libhttpserver-${version}";
     version = "git-${commit}";
-    commit = "4895f43ed29195af70beb47bcfd1ef3ab4555665";
+    commit = "36cef5bce3337caa858bc21aa0ca48c33d236b17";
     src = fetchFromGitHub {
       owner = "etr";
       repo = "libhttpserver";
       rev = commit;
-      sha256 = "1qg5frqvfhb8bpfiz9wivwjz2icy3si112grv188kgypws58n832";
+      hash = "sha256-reGFjtLNUNOiq6wGR5FmAZT6lv1UZyQoS8GxARfDkIY=";
     };
     propagatedBuildInputs = [ libmicrohttpd ];
     nativeBuildInputs = [ autoreconfHook gcc7 ];
@@ -76,6 +76,7 @@ rec {
         --replace "/usr/bin/file" "${file}/bin/file" \
         --replace "/bin/pwd" "${coreutils}/bin/pwd"
       mkdir build && cd build
+      export CFLAGS=-fpermissive CXXFLAGS="-fpermissive -std=c++11"
     '';
     meta = with lib; {
       homepage = "https://github.com/etr/libhttpserver";


### PR DESCRIPTION
- `stdenv.lib` is gone, just use `lib` (from `nixpkgs`)
- `gcc5` is gone, `gcc49` and `gcc6` don't work (missing symbols while linking ewig) -> use `gcc7` and update `libhttpserver` to 0.16.0

This is my first time using ewig ([great talk!](https://www.youtube.com/watch?v=sPhpelUfu8Q)) so I don't know how to properly test it. ewig starts and displays a file so I guess it can't be all bad. In addition, `ewig-debug` does open a webserver and it delivers its main page (but I don't have any browser with Javascript on that machine).