### PR TITLE
updated to the new LAGER_STRUCT

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,7 @@ releaseBuild = stdenv.mkDerivation rec {
     deps.scelta
     deps.utfcpp
     deps.lager
+    deps.zug
   ];
   meta = with lib; {
     homepage    = "https://github.com/arximboldi/ewig";

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -125,6 +125,7 @@ rec {
     propagatedBuildInputs = [
       boost
       immer
+      zug
       libhttpserver
       cereal
     ];
@@ -132,6 +133,24 @@ rec {
       homepage    = "https://github.com/arximboldi/lager";
       description = "library for functional interactive c++ programs";
       license     = licenses.lgpl3Plus;
+    };
+  };
+
+  zug = stdenv.mkDerivation rec {
+    name = "zug";
+    version = "git-${commit}";
+    commit = "deb266f4c7c35d325de7eb3d033f06e0809495f2";
+    src = fetchFromGitHub {
+      owner = "arximboldi";
+      repo = "zug";
+      rev = commit;
+      sha256 = "0af6xv22y35zyky07h52bwb2dksqz138sr59kxbnnj7vwsiq5j5s";
+    };
+    nativeBuildInputs = [ cmake ];
+    meta = with lib; {
+      homepage = "http://sinusoid.es/zug";
+      description = "Transducers for C++";
+      license = licenses.boost;
     };
   };
 }

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -107,12 +107,12 @@ rec {
   lager = stdenv.mkDerivation rec {
     name = "lager";
     version = "git-${commit}";
-    commit = "bee1c04c058b872ea998421d43587de9e90f079e";
+    commit = "56125daacdd2301ab2a8298801d247a593bd4d25";
     src = fetchFromGitHub {
       owner = "arximboldi";
       repo = "lager";
       rev = commit;
-      sha256 = "1222nydan0vflgfyijvkb1rwgspnbkimp05mm9zwzx6i3hhax4yk";
+      sha256 = "093kw3xahl9lgscbkkx5n6f0mmd0gwa4ra1l34gan1ywhf24kn9v";
     };
     buildInputs = [
       ncurses

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -6,12 +6,12 @@ rec {
   immer = stdenv.mkDerivation rec {
     name = "immer-${version}";
     version = "git-${commit}";
-    commit = "ed8999d81f1c7763705c829deb9122cde19195f4";
+    commit = "e5d79ed80ec74d511cc4f52fb68feeac66507f2c";
     src = fetchFromGitHub {
       owner = "arximboldi";
       repo = "immer";
       rev = commit;
-      sha256 = "009iazyjzzh4b5yg7d7y69g4p3gyj8ripgjxcbpyrp92967d45q7";
+      sha256 = "1h6m3hc26g15dhka6di6lphrl7wrgrxzn3nq0rfwg3iw10ifkw9f";
     };
     nativeBuildInputs = [ cmake ];
     buildInputs = [ boost ];

--- a/shell.nix
+++ b/shell.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     deps.scelta
     deps.utfcpp
     deps.lager
+    deps.zug
   ];
   shellHook = ''
     export EWIG_ROOT=`dirname ${toString ./shell.nix}`

--- a/src/ewig/application.cpp
+++ b/src/ewig/application.cpp
@@ -139,7 +139,7 @@ std::pair<application, lager::effect<action>> quit(application app)
 {
     return {
         put_message(app, "quitting... (waiting for operations to finish)"),
-        [] (auto&& ctx) { ctx.finish(); }
+        [] (auto&& ctx) { ctx.loop().finish(); }
     };
 }
 

--- a/src/ewig/application.hpp
+++ b/src/ewig/application.hpp
@@ -24,7 +24,7 @@
 #include <ewig/buffer.hpp>
 
 #include <lager/store.hpp>
-#include <lager/debug/cereal/struct.hpp>
+#include <lager/extra/cereal/struct.hpp>
 
 #include <ctime>
 #include <variant>
@@ -38,21 +38,17 @@ using arg_t = std::variant<std::monostate,
 struct key_action { key_code key; };
 struct resize_action { coord size; };
 struct command_action { immer::box<std::string> name; arg_t arg; };
-LAGER_CEREAL_STRUCT(key_action, (key));
-LAGER_CEREAL_STRUCT(resize_action, (size));
-LAGER_CEREAL_STRUCT(command_action, (name)(arg));
 
 using action = std::variant<command_action,
                            key_action,
-                           resize_action,
-                           buffer_action>;
+                           buffer_action,
+                           resize_action>;
 
 struct message
 {
     std::time_t time_stamp;
     immer::box<std::string> content;
 };
-LAGER_CEREAL_STRUCT(message, (time_stamp)(content));
 
 struct application
 {
@@ -63,9 +59,6 @@ struct application
     immer::vector<text> clipboard;
     immer::vector<message> messages;
 };
-LAGER_CEREAL_STRUCT(
-    application,
-    (window_size)(keys)(input)(current)(clipboard)(messages));
 
 using command = std::function<
     std::pair<application, lager::effect<action>>(
@@ -87,3 +80,9 @@ application apply_edit(application state, coord size, buffer edit);
 application apply_edit(application state, coord size, std::pair<buffer, text> edit);
 
 } // namespace ewig
+
+LAGER_STRUCT(ewig, key_action, key);
+LAGER_STRUCT(ewig, resize_action, size);
+LAGER_STRUCT(ewig, command_action, name, arg);
+LAGER_STRUCT(ewig, message, time_stamp, content);
+LAGER_STRUCT(ewig, application, window_size, keys, input, current, clipboard, messages);

--- a/src/ewig/buffer.hpp
+++ b/src/ewig/buffer.hpp
@@ -23,7 +23,7 @@
 #include <ewig/coord.hpp>
 
 #include <lager/store.hpp>
-#include <lager/debug/cereal/struct.hpp>
+#include <lager/extra/struct.hpp>
 
 #include <immer/box.hpp>
 #include <immer/flex_vector.hpp>
@@ -44,17 +44,15 @@ using text = immer::flex_vector<line>;
 
 struct no_file
 {
-    static immer::box<std::string> name;
-    static text content;
+    immer::box<std::string> name = "*unnamed*";
+    text content = {};
 };
-LAGER_CEREAL_STRUCT(no_file, (name)(content));
 
 struct existing_file
 {
     immer::box<std::string> name;
     text content;
 };
-LAGER_CEREAL_STRUCT(existing_file, (name)(content));
 
 struct saving_file
 {
@@ -62,7 +60,6 @@ struct saving_file
     text content;
     std::size_t saved_lines;
 };
-LAGER_CEREAL_STRUCT(saving_file, (name)(content));
 
 struct loading_file
 {
@@ -71,7 +68,6 @@ struct loading_file
     std::streamoff loaded_bytes;
     std::streamoff total_bytes;
 };
-LAGER_CEREAL_STRUCT(loading_file, (name)(content)(loaded_bytes)(total_bytes));
 
 using file = std::variant<no_file,
                           existing_file,
@@ -83,7 +79,6 @@ struct snapshot
     text content;
     coord cursor;
 };
-LAGER_CEREAL_STRUCT(snapshot, (content)(cursor));
 
 struct buffer
 {
@@ -95,9 +90,6 @@ struct buffer
     immer::vector<snapshot> history;
     std::optional<std::size_t> history_pos;
 };
-LAGER_CEREAL_STRUCT(
-    buffer,
-    (from)(content)(cursor)(scroll)(selection_start)(history)(history_pos));
 
 struct load_progress_action { loading_file file; };
 struct load_done_action { existing_file file; };
@@ -105,12 +97,6 @@ struct load_error_action { existing_file file; std::exception_ptr err; };
 struct save_progress_action { saving_file file; };
 struct save_done_action { existing_file file; };
 struct save_error_action { existing_file file; std::exception_ptr err; };
-LAGER_CEREAL_STRUCT(load_progress_action, (file));
-LAGER_CEREAL_STRUCT(load_done_action, (file));
-LAGER_CEREAL_STRUCT(load_error_action, (file));
-LAGER_CEREAL_STRUCT(save_progress_action, (file));
-LAGER_CEREAL_STRUCT(save_done_action, (file));
-LAGER_CEREAL_STRUCT(save_error_action, (file));
 
 using buffer_action = std::variant<load_progress_action,
                                    load_done_action,
@@ -192,3 +178,16 @@ buffer undo(buffer);
 std::pair<buffer, std::string> record(buffer before, buffer after);
 
 } // namespace ewig
+
+LAGER_STRUCT(ewig, no_file, name, content);
+LAGER_STRUCT(ewig, existing_file, name, content);
+LAGER_STRUCT(ewig, saving_file, name, content, saved_lines);
+LAGER_STRUCT(ewig, loading_file, name, content, loaded_bytes, total_bytes);
+LAGER_STRUCT(ewig, snapshot, content, cursor);
+LAGER_STRUCT(ewig, buffer, from, content, cursor, scroll, selection_start, history, history_pos);
+LAGER_STRUCT(ewig, load_progress_action, file);
+LAGER_STRUCT(ewig, load_done_action, file);
+LAGER_STRUCT(ewig, load_error_action, file, err);
+LAGER_STRUCT(ewig, save_progress_action, file);
+LAGER_STRUCT(ewig, save_done_action, file);
+LAGER_STRUCT(ewig, save_error_action, file, err);

--- a/src/ewig/coord.hpp
+++ b/src/ewig/coord.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <lager/debug/cereal/struct.hpp>
+#include <lager/extra/struct.hpp>
 
 namespace ewig {
 
@@ -31,21 +31,12 @@ struct coord
     index row = {};
     index col = {};
 };
-LAGER_CEREAL_STRUCT(coord, (row)(col));
 
 inline bool operator<(const coord& a, const coord& b)
 {
     return a.row < b.row || (a.row == b.row && a.col < b.col);
 }
 
-inline bool operator==(const coord& a, const coord& b)
-{
-    return a.row == b.row && a.col == b.col;
-}
-
-inline bool operator!=(const coord& a, const coord& b)
-{
-    return !(a == b);
-}
-
 } // namespace ewig
+
+LAGER_STRUCT(ewig, coord, row, col);


### PR DESCRIPTION
Needed to build ewig with a >= 2022 lager master. 

BTW I noticed lager version is 0.0.0. Although there is no versioned release (yet), bumping the version, especially on breaking change, still helps to refer to a version in use, and to make commit message more clear (ex: "bump to lager 0.1.0").